### PR TITLE
feat: adds the prettier plugin for tailwindcss if prettier is used

### DIFF
--- a/src/creator.js
+++ b/src/creator.js
@@ -74,6 +74,8 @@ export async function createSkeleton(opts) {
 		'@skeletonlabs/skeleton',
 	];
 
+	if (opts?.prettier) packages.push('prettier-plugin-tailwindcss');
+
 	if (opts?.typography) packages.push('@tailwindcss/typography');
 	if (opts?.forms) packages.push('@tailwindcss/forms');
 	if (opts?.lineclamp) packages.push('@tailwindcss/line-clamp');


### PR DESCRIPTION
The plugin puts the used tailwindcss utility classes in order

Since a skeleton project is using tailwindcss, we should add the prettier plugin for tailwindcss if prettier is selected. 

Improves DX