### PR TITLE
btn-filled was replaced by variant-filled

### DIFF
--- a/templates/welcome/src/routes/+page.svelte
+++ b/templates/welcome/src/routes/+page.svelte
@@ -20,7 +20,7 @@
 		<!-- / -->
 		<div class="flex justify-center space-x-2">
 			<a
-				class="btn btn-filled"
+				class="btn variant-filled"
 				href="https://skeleton.dev/"
 				target="_blank"
 				rel="noreferrer"


### PR DESCRIPTION
btn-filled was replaced by variant-filled a few iterations ago

- there is no utility class named btn-filled in current versions of skeleton